### PR TITLE
Updated escEscRegex to cover the global replacement of backslashes

### DIFF
--- a/__tests__/lib/Lexer.test.js
+++ b/__tests__/lib/Lexer.test.js
@@ -77,12 +77,12 @@ describe('Lexer', () => {
   })
   describe('Tokens', () => {
     it('unquotes string elements', () => {
-      const tokens = inst.getTokens(['"foo \\"bar\\\\"'])
+      const tokens = inst.getTokens(['"foo \\"bar\\\\jump\\\\"'])
       expect(tokens).toEqual([
         {
           type: 'literal',
-          value: 'foo "bar\\',
-          raw: '"foo \\"bar\\\\"'
+          value: 'foo "bar\\jump\\',
+          raw: '"foo \\"bar\\\\jump\\\\"'
         }
       ])
     })

--- a/__tests__/lib/Lexer.test.js
+++ b/__tests__/lib/Lexer.test.js
@@ -77,12 +77,12 @@ describe('Lexer', () => {
   })
   describe('Tokens', () => {
     it('unquotes string elements', () => {
-      const tokens = inst.getTokens(['"foo \\"bar\\\\jump\\\\"'])
+      const tokens = inst.getTokens(['"foo \\"bar\\\\baz\\\\"'])
       expect(tokens).toEqual([
         {
           type: 'literal',
-          value: 'foo "bar\\jump\\',
-          raw: '"foo \\"bar\\\\jump\\\\"'
+          value: 'foo "bar\\baz\\',
+          raw: '"foo \\"bar\\\\baz\\\\"'
         }
       ])
     })

--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -5,7 +5,7 @@
 
 const numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/
 const identRegex = /^[a-zA-Zа-яА-Я_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$][a-zA-Zа-яА-Я0-9_\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF$]*$/
-const escEscRegex = /\\\\/
+const escEscRegex = /\\\\/g
 const whitespaceRegex = /^\s*$/
 const preOpRegexElems = [
   // Strings


### PR DESCRIPTION
**Bug:**
```
inst.getTokens(['"foo \\"bar\\\\baz\\\\"']).value === 'foo "bar\\baz\\\\'
```
**Expected:**
```
inst.getTokens(['"foo \\"bar\\\\baz\\\\"']).value === 'foo "bar\\baz\\'
```
**Root Cause:**
The regex escEscRegex used by _unquote(str) function only replaces the first backslash. It shall replace all the backslashes.

**Fix:**
```
const escEscRegex = /\\\\/g
```